### PR TITLE
Proposing an update to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,28 @@
 ## Introduction
 
-This software enables a "Voting Ambassador" workflow for get-out-the-vote campaigns. A Vote Ambassador signs up with the [hello-voter](https://github.com/colab-coop/hello-voter) React front-end. The Vote Ambassador, once signed up, is provided a list of voters in their area (within some configurable number of meters from the Ambassador). This distance is calculated via the Neo4J apoc.distance function, using the Point data type either imported from CSV in the case of a Tripler, or pulled from an external API in the case of Ambassadors. This list must of course be imported using the import script found in `/server/scripts/importer` (NOTE! CSV format, very specific column order). The Vote Ambassador contacts these voters (called Vote Triplers) and encourages them to help 3 additional people vote (called Triplees). Once the Vote Tripler responds "YES" to the system's SMS (this software assumes Twilio SMS integration), the Vote Ambassador will receive payment from the organization who has set up this software. Currently this software assumes payment via Stripe + Plaid, though Paypal is at least somewhat working.
+This software enables a "Voting Ambassador" workflow for get-out-the-vote campaigns. A Vote Ambassador signs up with the [hello-voter](https://github.com/colab-coop/hello-voter) React front-end serviced by the backend contained in this repo.
+
+## Development Setup
+
+### Prerequisites
+
+**Docker** - Docker is required to get the database running, so make sure you have that installed on your system.
+
+**JDK 1.8** - JDK (not JRE) 1.8 is required for the server. You need to have this installed and your JAVA_HOME environment variable set in order to successfully build and start the server.
+
+To get set up locally, simply run the following commands:
+
+    git clone git@github.com:colab-coop/HelloVoter.git
+    cd HelloVoter
+    npm install
+    npm run database
+    npm start
+
+This should initialize the database + Docker instance and start the server.
+
+## About This App
+
+The Vote Ambassador, once signed up, is provided a list of voters in their area (within some configurable number of meters from the Ambassador). This distance is calculated via the Neo4J apoc.distance function, using the Point data type either imported from CSV in the case of a Tripler, or pulled from an external API in the case of Ambassadors. This list must of course be imported using the import script found in `/server/scripts/importer` (NOTE! CSV format, very specific column order). The Vote Ambassador contacts these voters (called Vote Triplers) and encourages them to help 3 additional people vote (called Triplees). Once the Vote Tripler responds "YES" to the system's SMS (this software assumes Twilio SMS integration), the Vote Ambassador will receive payment from the organization who has set up this software. Currently this software assumes payment via Stripe + Plaid, though Paypal is at least somewhat working.
 
 ## History
 


### PR DESCRIPTION
Suggestion for update to the README.

- Added Development Setup back into README
- Added JDK 1.8 requirement note
- Reformatted a little, explanation below

There is a LOT of great info in this README but something got lost in translation from the release tagged branches. The development setup info is gone, and the Introduction, whilst valuable, is super lengthy. Suggest the intro at the top be shortened and important developer info be inserted. The remainder of the intro is moved a bit lower.

This really is all great info but the audience of a GitHub repo is primarily developers and we developers will lose interest fast if bombarded with walls of text.