### PR TITLE
Twilio Carrier API Lookup and BLOCKED_CARRIERS env var

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -1,4 +1,5 @@
 DEBUG=true
+BLOCKED_CARRIERS=TextNow - Bandwidth.com - SVR
 
 NEO4J_PROTOCOL=bolt
 NEO4J_HOST=localhost

--- a/server/README.md
+++ b/server/README.md
@@ -80,6 +80,7 @@ For this server, configure an `.env` file. The following is a complete list of v
     ALLOWED_STATES=
     TRIPLER_CONFIRMED_AMBASSADOR_NOTIFICATION=
     FIRST_REWARD_PAYOUT=
+    BLOCKED_CARRIERS=
 
 The meaning of each config item is as follows:
 
@@ -160,4 +161,5 @@ The meaning of each config item is as follows:
 * `ALLOWED_STATES`: A comma-separated list of 2-letter US state codes that determine which addresses are valid for ambassador signups
 * `TRIPLER_CONFIRMED_AMBASSADOR_NOTIFICATION`: The SMS message that gets sent to the ambassador when one of their triplers is confirmed.
 * `FIRST_REWARD_PAYOUT`: The amount an ambassador receives as a reward for one of their claimed triplers upgrading to an ambassador and confirming a tripler.
+* `BLOCKED_CARRIERS`: A pipe-delimited list of carrier strings in order to block fraudulent phone numbers.
 

--- a/server/app/lib/carrier.js
+++ b/server/app/lib/carrier.js
@@ -1,0 +1,19 @@
+import logger from 'logops';
+import { international as phoneFormat } from './phone';
+import { ov_config } from './ov_config';
+
+const client = require('twilio')(ov_config.twilio_account_sid, ov_config.twilio_auth_token, { 
+    lazyLoading: true 
+});
+
+module.exports = (phone, callback) => {
+  logger.debug(`Checking carrier for ${phoneFormat(phone)}`);
+
+  if (ov_config.twilio_disable) {
+    logger.debug('Bypassing carrier lookup');
+    return;
+  }
+
+  return client.lookups.phoneNumbers(phoneFormat(phone))
+    .fetch({type:['carrier']})
+};

--- a/server/app/lib/carrier.js
+++ b/server/app/lib/carrier.js
@@ -21,16 +21,12 @@ const client = require('twilio')(ov_config.twilio_account_sid, ov_config.twilio_
 
 module.exports = async (phone) => {
 
-  logger.debug(`Checking carrier for ${phoneFormat(phone)}`);
+  logger.debug(`[TWILIO] Checking carrier for ${phoneFormat(phone)}`);
 
-  if (ov_config.twilio_disable) {
-    logger.debug('[TWILIO] Twilio disabled in config, bypassing carrier lookup');
-    return;
-  }
-
-  // Exit early and don't perform a lookup if nothing is blocked in config.
+  // Exit early and don't perform a lookup if nothing is blocked in config
+  // or if Twilio is disabled in config.
   let blockedCarrierString = ov_config.blocked_carriers
-  if(!blockedCarrierString) {
+  if(!blockedCarrierString || ov_config.twilio_disable) {
     let result = new Promise((resolve, reject) => {
       let carrier = {
         "caller_name": null,
@@ -48,7 +44,7 @@ module.exports = async (phone) => {
         "add_ons": null,
         "url": null
       }
-      logger.debug(`[TWILIO] Carrier lookup skipped, BLOCKED_CARRIERS env not set or empty.`);
+      logger.debug(`[TWILIO] Carrier lookup skipped, either TWILIO_DISABLE is set in env or BLOCKED_CARRIERS env not set or empty.`);
       resolve(carrier)
     });
     return result;

--- a/server/app/lib/carrier.js
+++ b/server/app/lib/carrier.js
@@ -1,3 +1,16 @@
+/**
+ * Wrapper plus some logic around the Twilio Carrier API.
+ * 
+ * This function reads a pipe delimited list of strings from the
+ * "BLOCKED_CARRIERS" env param and calls Twilio to get the
+ * carrier name of the supplied phone number.
+ * 
+ * The function will return the carrier lookup info, additionally
+ * decorated with lookup.carrier.isBlocked = (null) <true/false>
+ * 
+ * ref: https://www.twilio.com/docs/lookup/api
+ */
+
 import logger from 'logops';
 import { international as phoneFormat } from './phone';
 import { ov_config } from './ov_config';
@@ -6,14 +19,56 @@ const client = require('twilio')(ov_config.twilio_account_sid, ov_config.twilio_
     lazyLoading: true 
 });
 
-module.exports = (phone, callback) => {
+module.exports = async (phone) => {
+
   logger.debug(`Checking carrier for ${phoneFormat(phone)}`);
 
   if (ov_config.twilio_disable) {
-    logger.debug('Bypassing carrier lookup');
+    logger.debug('[TWILIO] Twilio disabled in config, bypassing carrier lookup');
     return;
   }
 
-  return client.lookups.phoneNumbers(phoneFormat(phone))
-    .fetch({type:['carrier']})
+  // Exit early and don't perform a lookup if nothing is blocked in config.
+  let blockedCarrierString = ov_config.blocked_carriers
+  if(!blockedCarrierString) {
+    let result = new Promise((resolve, reject) => {
+      let carrier = {
+        "caller_name": null,
+        "carrier": {
+          "error_code": null,
+          "mobile_country_code": null,
+          "mobile_network_code": null,
+          "name": "Carrier Lookup Skipped",
+          "type": null,
+          "isBlocked": null,
+        },
+        "country_code": null,
+        "national_format": null,
+        "phone_number": null,
+        "add_ons": null,
+        "url": null
+      }
+      logger.debug(`[TWILIO] Carrier lookup skipped, BLOCKED_CARRIERS env not set or empty.`);
+      resolve(carrier)
+    });
+    return result;
+  }
+
+  let lookup = await client.lookups.phoneNumbers(phoneFormat(phone))
+    .fetch({type:['carrier']});
+
+  let blockedCarriers = blockedCarrierString.split('|').map((val) => val.toUpperCase());
+  if(lookup.carrier.error_code !== null) {
+    logger.info(`[TWILIO] Carrier lookup failed with error code ${lookup.carrier.error_code}`);
+    lookup.carrier.isBlocked = null;
+    return lookup;
+  } else {
+    let carrierName = lookup.carrier.name.toUpperCase()
+    let isBlocked = blockedCarriers.includes(carrierName)
+    if(isBlocked) {
+      logger.info(`[TWILIO] Carrier ${carrierName} for ${phoneFormat(phone)} is blocked in config`);
+    }
+    lookup.carrier.isBlocked = isBlocked;
+    return lookup;
+  }
 };

--- a/server/app/lib/ov_config.js
+++ b/server/app/lib/ov_config.js
@@ -86,4 +86,5 @@ export const ov_config = {
   allowed_states: getConfig('allowed_states', true, []),
   tripler_confirmed_ambassador_notification: getConfig('tripler_confirmed_ambassador_notification', true, null),
   first_reward_payout: getConfig('first_reward_payout', true, 0),
+  blocked_carriers: ["TEXTNOW"]
 };

--- a/server/app/lib/ov_config.js
+++ b/server/app/lib/ov_config.js
@@ -86,5 +86,6 @@ export const ov_config = {
   allowed_states: getConfig('allowed_states', true, []),
   tripler_confirmed_ambassador_notification: getConfig('tripler_confirmed_ambassador_notification', true, null),
   first_reward_payout: getConfig('first_reward_payout', true, 0),
-  blocked_carriers: ["TEXTNOW"]
+  // This should be a pipe delimited list of strings
+  blocked_carriers: getConfig('blocked_carriers', false, "")
 };

--- a/server/app/lib/sms.js
+++ b/server/app/lib/sms.js
@@ -1,7 +1,6 @@
 import logger from 'logops';
 import { international as phoneFormat } from './phone';
 import { ov_config } from './ov_config';
-import { carrier } from './carrier';
 
 const client = require('twilio')(ov_config.twilio_account_sid, ov_config.twilio_auth_token, { 
     lazyLoading: true 
@@ -13,19 +12,6 @@ module.exports = (to, message) => {
   if (ov_config.twilio_disable) {
     logger.debug('Bypassing sending SMS');
     return;
-  }
-
-  try {
-    let lookup = await carrier(to);
-    let blockedCarriers = ov_config.blocked_carriers
-    let blockTest = new RegExp( blockedCarriers.join("|"), "i");
-    let isBlocked = blockTest.test(lookup.carrier.name);
-    if(isBlocked) {
-      logger.info(`Blocked sending message to ${phoneFormat(to)} because carrier ${lookup.carrier.name} is blocked in config`);
-      throw `Blocked sending message to ${phoneFormat(to)} because carrier ${lookup.carrier.name} is blocked in config`;
-    }
-  } catch(err) {
-    logger.info(`Won't send SMS because ${err}`)
   }
 
   return client.messages.create({from: ov_config.twilio_from, to: phoneFormat(to), body: message});

--- a/server/app/lib/sms.js
+++ b/server/app/lib/sms.js
@@ -1,6 +1,7 @@
 import logger from 'logops';
 import { international as phoneFormat } from './phone';
 import { ov_config } from './ov_config';
+import { carrier } from './carrier';
 
 const client = require('twilio')(ov_config.twilio_account_sid, ov_config.twilio_auth_token, { 
     lazyLoading: true 
@@ -12,6 +13,19 @@ module.exports = (to, message) => {
   if (ov_config.twilio_disable) {
     logger.debug('Bypassing sending SMS');
     return;
+  }
+
+  try {
+    let lookup = await carrier(to);
+    let blockedCarriers = ov_config.blocked_carriers
+    let blockTest = new RegExp( blockedCarriers.join("|"), "i");
+    let isBlocked = blockTest.test(lookup.carrier.name);
+    if(isBlocked) {
+      logger.info(`Blocked sending message to ${phoneFormat(to)} because carrier ${lookup.carrier.name} is blocked in config`);
+      throw `Blocked sending message to ${phoneFormat(to)} because carrier ${lookup.carrier.name} is blocked in config`;
+    }
+  } catch(err) {
+    logger.info(`Won't send SMS because ${err}`)
   }
 
   return client.messages.create({from: ov_config.twilio_from, to: phoneFormat(to), body: message});

--- a/server/app/routes/api/v1/va/triplers.js
+++ b/server/app/routes/api/v1/va/triplers.js
@@ -217,6 +217,11 @@ async function startTriplerConfirmation(req, res) {
     return _400(res, "You entered your phone number as the number of this Vote Tripler. Please try again.");
   }
 
+  let carrierLookup = await carrier(triplerPhone);
+  if(carrierLookup.carrier.isBlocked) {
+    return _400(res, `We're sorry, due to fraud concerns '${carrierLookup.carrier.name}' phone numbers are not permitted. Please try again.`);
+  }
+
   try {
     triplersSvc.startTriplerConfirmation(ambassador, tripler, triplerPhone, triplees);
   } catch (err) {

--- a/server/app/routes/api/v1/va/triplers.js
+++ b/server/app/routes/api/v1/va/triplers.js
@@ -18,7 +18,7 @@ import {
 import { serializeTripler, serializeNeo4JTripler, serializeTriplee } from './serializers';
 
 import sms from '../../../../lib/sms';
-
+import carrier from '../../../../lib/carrier';
 
 async function createTripler(req, res) {
   let new_tripler = null


### PR DESCRIPTION
This enables blocking of TextNow or any other carrier string.

The BLOCKED_CARRIERS env should be supplied a pipe delimited list of strings, or empty.

`BLOCKED_CARRIERS=TextNow - Bandwidth.com - SVR`

Here is a phone number I setup on TextNow that you can use for testing - `(612) 428-3486`

I tested with this var present, not present, set, empty and also with Twilio disabled and enabled. There are comments at the top of carrier.js worth reading. Basically we skip the lookup altogether in multiple cases, which I think makes sense.

@brodavi - I tested all of the carrier lib quite thoroughly in my local environment but I don't really have a way to validate that my tripler.js validation is doing what it should. Can you pull this and take a crack at it?

Also - What do we want the failed validation message to say? Take a look and let me know, happy to update PR with different text.