### PR TITLE
Convert ambassador's state to uppercase when signing up

### DIFF
--- a/server/app/services/ambassadors.js
+++ b/server/app/services/ambassadors.js
@@ -59,8 +59,13 @@ async function signup(json) {
     throw new ValidationError("Our system doesn’t recognize that phone number. Please try again.");
   }
 
-  let allowed_states = ov_config.allowed_states.split(',');
-  if (allowed_states.indexOf(json.address.state) === -1) {
+  // Ensure that address.state is always uppercase
+  let address = json.address;
+  address.state = address.state.toUpperCase();
+
+
+  let allowed_states = ov_config.allowed_states.toUpperCase().split(',');
+  if (allowed_states.indexOf(address.state) === -1) {
     throw new ValidationError("Sorry, but state employment laws don't allow us to pay Voting Ambassadors in your state.")
   }
 
@@ -87,7 +92,7 @@ async function signup(json) {
     }
   }
 
-  let coordinates = await geoCode(json.address);
+  let coordinates = await geoCode(address);
   if (coordinates === null) {
     throw new ValidationError("Our system doesn’t recognize that address. Please try again.");
   }
@@ -127,7 +132,7 @@ async function signup(json) {
     phone: normalize(json.phone),
     email: json.email || null,
     date_of_birth: json.date_of_birth || null,
-    address: JSON.stringify(json.address),
+    address: JSON.stringify(address),
     quiz_results: JSON.stringify(json.quiz_results) || null,
     approved: true,
     locked: false,


### PR DESCRIPTION
`indexOf()` is case sensitive, so this code converts both the list of allowed states and the state in the JSON request to uppercase before doing the search to ensure a case insensitive match. It then saves the state into Neo4J as uppercase for consistency.

I tested this MR by:
- running `POST {{base_url}}/api/v1/va/ambassadors/signup` locally through Postman
- My local environment had `co` as the state name and I used `Co` in the request body
- Confirmed I was able to get a 200 response w/ success message
- Confirmed I that the state was saved as CO in Neo4j

See:
https://github.com/colab-coop/hello-voter/issues/121
https://github.com/colab-coop/HelloVoter/issues/46