### PR TITLE
Much faster seeding

### DIFF
--- a/server/scripts/seed_db.js
+++ b/server/scripts/seed_db.js
@@ -61,6 +61,12 @@ const argv = yargs
       type: 'boolean'
     }
   })
+  .option({
+    'real-geocodes': {
+      describe: 'use a live geocoder to determine address locations (slow)',
+      type: 'boolean'
+    }
+  })
   .help()
   .argv
 
@@ -80,7 +86,10 @@ async function emptyDatabase() {
 
 async function baseUserData() {
   const address = addresses[faker.random.number({ min: 0, max: addresses.length - 1 })];
-  const coordinates = await geoCode(address);
+  const coordinates = argv['real-geocodes'] ? await geoCode(address) : {
+    latitude: faker.address.latitude(),
+    longitude: faker.address.longitude(),
+  };
   const user = {
     id: uuidv4(),
     first_name: faker.name.firstName(),

--- a/server/scripts/seed_db.js
+++ b/server/scripts/seed_db.js
@@ -81,18 +81,26 @@ async function emptyDatabase() {
 async function baseUserData() {
   const address = addresses[faker.random.number({ min: 0, max: addresses.length - 1 })];
   const coordinates = await geoCode(address);
-  return {
+  const user = {
     id: uuidv4(),
     first_name: faker.name.firstName(),
     last_name: faker.name.lastName(),
+    gender: faker.random.arrayElement(['F', 'M', 'U']),
     phone: await randomPhone('Ambassador'),
+    age_decade: faker.random.arrayElement(["20-29", "30-39", "40-49"]),
     email: faker.internet.email(),
     address: JSON.stringify(address),
+    zip: address.zip,
+    msa: `${address.state} other`,
     location: {
       latitude: parseFloat(coordinates.latitude),
       longitude: parseFloat(coordinates.longitude)
     },
   };
+  return {
+    ...user,
+    full_name: `${user.first_name} ${user.last_name}`,
+  }
 }
 
 async function createTripler({ status }) {

--- a/server/scripts/seed_db.js
+++ b/server/scripts/seed_db.js
@@ -3,58 +3,66 @@
 import faker from 'faker';
 import { geoCode } from '../app/lib/utils.js';
 import { v4 as uuidv4 } from 'uuid';
-import neode from  '../app/lib/neode.js';
+import neode from '../app/lib/neode.js';
 import addresses from './seed_data/addresses.json';
 import { normalizePhone } from '../app/lib/normalizers';
 import yargs from 'yargs';
 
 const argv = yargs
-               .scriptName("seed_db.js")
-               .usage('$0 <cmd> [options]')
-               .command('seedall', 'seed with random Ambassadors and Triplers, optionally delete all first', async function (argv) {
-                 await seed(argv.argv)
-                         .then( () => { process.exit(0) } )
-                         .catch( (err)=>{ console.log(err); process.exit(1); } );
-               })
-               .command('delete', 'only delete all the Ambassadors and Triplers, do not seed', async function () {
-                 await emptyDatabase()
-                         .then( () => { process.exit(0) } )
-                         .catch( (err)=>{ console.log(err); process.exit(1); } );
-               })
-               .option({
-                 'max-ambassadors': {
-                   alias: 'ma',
-                   describe: 'defines a maximum number of Ambassadors to create',
-                   type: 'number'
-                 }
-               })
-               .option({
-                 'max-triplers': {
-                   alias: 'mt',
-                   describe: 'defines a maximum number of Triplers to create',
-                   type: 'number'
-                 }
-               })
-               .option({
-                 'empty': {
-                   describe: 'empty the database before you seed it',
-                   type: 'boolean'
-                 }
-               })
-               .option({
-                 'seed': {
-                   describe: 'define a random number generation seed to reproduce a state',
-                   type: 'number'
-                 }
-               })
-               .option({
-                 'force-unconfirmed': {
-                   describe: 'force all triplers to be created with "unconfirmed" status',
-                   type: 'boolean'
-                 }
-               })
-               .help()
-               .argv
+  .scriptName("seed_db.js")
+  .usage('$0 <cmd> [options]')
+  .command('seedall', 'seed with random Ambassadors and Triplers, optionally delete all first', async function (argv) {
+    try {
+      await seed(argv.argv);
+      process.exit(0);
+    } catch (err) {
+      console.log(err);
+      process.exit(1);
+    }
+  })
+  .command('delete', 'only delete all the Ambassadors and Triplers, do not seed', async function () {
+    try {
+      await emptyDatabase();
+      process.exit(0);
+    } catch (err) {
+      console.log(err);
+      process.exit(1);
+    }
+  })
+  .option({
+    'max-ambassadors': {
+      alias: 'ma',
+      describe: 'defines a maximum number of Ambassadors to create',
+      type: 'number'
+    }
+  })
+  .option({
+    'max-triplers': {
+      alias: 'mt',
+      describe: 'defines a maximum number of Triplers to create',
+      type: 'number'
+    }
+  })
+  .option({
+    'empty': {
+      describe: 'empty the database before you seed it',
+      type: 'boolean'
+    }
+  })
+  .option({
+    'seed': {
+      describe: 'define a random number generation seed to reproduce a state',
+      type: 'number'
+    }
+  })
+  .option({
+    'force-unconfirmed': {
+      describe: 'force all triplers to be created with "unconfirmed" status',
+      type: 'boolean'
+    }
+  })
+  .help()
+  .argv
 
 async function randomPhone(model) {
   while (true) {
@@ -75,7 +83,7 @@ async function createTripler(opts) {
   let lastName = faker.name.lastName();
   let phone = await randomPhone('Ambassador');
   let email = faker.internet.email();
-  let address = addresses[faker.random.number({min: 0, max: addresses.length - 1})];
+  let address = addresses[faker.random.number({ min: 0, max: addresses.length - 1 })];
   let coordinates = await geoCode(address);
   let triplees = [faker.name.findName(), faker.name.findName(), faker.name.findName()];
 
@@ -93,7 +101,7 @@ async function createTripler(opts) {
     status: argv['force-unconfirmed'] ? 'unconfirmed' : opts.status,
     triplees: JSON.stringify(triplees)
   }
-  return await neode.create('Tripler', json);
+  return neode.create('Tripler', json);
 }
 
 async function createAmbassador(opts) {
@@ -101,7 +109,7 @@ async function createAmbassador(opts) {
   let lastName = faker.name.lastName();
   let phone = await randomPhone('Ambassador');
   let email = faker.internet.email();
-  let address = addresses[faker.random.number({min: 0, max: addresses.length - 1})];
+  let address = addresses[faker.random.number({ min: 0, max: addresses.length - 1 })];
   let coordinates = await geoCode(address);
 
   let json = {
@@ -125,8 +133,8 @@ async function createAmbassador(opts) {
   let new_ambassador = await neode.create('Ambassador', json);
   if (opts.createTriplers) {
     let statuses = ['pending', 'unconfirmed', 'confirmed'];
-    let status = statuses[faker.random.number({min: 0, max: 2})];
-    let max = faker.random.number({min: 1, max: 2});
+    let status = statuses[faker.random.number({ min: 0, max: 2 })];
+    let max = faker.random.number({ min: 1, max: 2 });
     for (let index = 0; index < max; index++) {
       console.log(`Creating ${status} tripler ${index + 1} of ${max} ...`);
       let tripler = await createTripler({ status: status });
@@ -137,7 +145,7 @@ async function createAmbassador(opts) {
 }
 
 async function createAdmin() {
-  return await createAmbassador({admin: true});
+  return createAmbassador({ admin: true });
 }
 
 async function seed(argv) {
@@ -155,37 +163,36 @@ async function seed(argv) {
   console.log(`Admin created with email ${admin.get('email')}`);
 
   console.log("Creating approved ambassador...");
-  let ambassador = await createAmbassador({approved: true, signupCompleted: true, createTriplers: true});
+  let ambassador = await createAmbassador({ approved: true, signupCompleted: true, createTriplers: true });
   console.log(`Ambassador created with email ${ambassador.get('email')}`);
 
   console.log("Creating unapproved ambassador...");
-  ambassador = await createAmbassador({approved: false, signupCompleted: false, createTriplers: false});
+  ambassador = await createAmbassador({ approved: false, signupCompleted: false, createTriplers: false });
   console.log(`Ambassador created with email ${ambassador.get('email')}`);
 
   console.log("Creating locked ambassador...");
-  ambassador = await createAmbassador({locked: true, approved: true, signupCompleted: true, createTriplers: true});
+  ambassador = await createAmbassador({ locked: true, approved: true, signupCompleted: true, createTriplers: true });
   console.log(`Ambassador created with email ${ambassador.get('email')}`);
 
   // Create some number of ambassadors (random btw 1 - 10 if not specified in args)
-  let max = argv['max-ambassadors'] || faker.random.number({min: 1, max: 10});
+  let max = argv['max-ambassadors'] || faker.random.number({ min: 1, max: 10 });
   for (let index = 0; index < max; index++) {
     let approved = faker.random.boolean();
     let locked = faker.random.boolean();
     let signupCompleted = faker.random.boolean();
 
     console.log(`Creating {locked: ${locked}, approved: ${approved}, signup_completed: ${signupCompleted}} ambassador ${index + 1} of ${max} ...`);
-    let ambassador = await createAmbassador({createTriplers: true});
+    let ambassador = await createAmbassador({ createTriplers: true });
 
     console.log(`Ambassador created with email ${ambassador.get('email')}`);
   }
 
   // Create some number of triplers (random btw 1 - 30 if not specified in args)
-  max = argv['max-triplers'] || faker.random.number({min: 1, max: 30});
+  max = argv['max-triplers'] || faker.random.number({ min: 1, max: 30 });
   let statuses = ['pending', 'unconfirmed', 'confirmed'];
-  let status = statuses[faker.random.number({min: 0, max: 2})];
+  let status = statuses[faker.random.number({ min: 0, max: 2 })];
   for (let index = 0; index < max; index++) {
     console.log(`Creating ${status} tripler ${index + 1} of ${max} ...`);
-    let tripler = await createTripler({ status: status } );
+    await createTripler({ status: status });
   }
 }
-


### PR DESCRIPTION
### Changes

- Cuts down seed time from ~30 seconds to less than 1 second by faking the geocodes by default. You can still geocode live by passing --real-geocodes e.g. `(cd server; npm run seed:fresh -- --real-geocodes=true)`
- Adds denormalized seed data such as `full_name` and `zip` for local testing of features like [search filters](https://github.com/colab-coop/HelloVoter/pull/94).
- Adds some real indexes automatically during seeding (may not be all of them, but at least the indexes that are necessary for the "search filters" query)