### PR TITLE
Search fixes

### DIFF
--- a/server/app/lib/normalizers.js
+++ b/server/app/lib/normalizers.js
@@ -8,6 +8,10 @@ const WGS_84_2D = 4326;
 
 const ALLOWED_ATTRS = ['first_name', 'last_name', 'date_of_birth', 'email', 'status'];
 
+export function normalizeGender(gender) {
+  return (gender || "U").replace("Female", "F").replace("Male", "M");
+}
+
 export function normalizeAddress(address) {
   return {
     ...address,

--- a/server/app/services/__snapshots__/triplers.jest.js.snap
+++ b/server/app/services/__snapshots__/triplers.jest.js.snap
@@ -5,28 +5,29 @@ exports[`triplers search query with age only 1`] = `
     match (a:Ambassador {id: \\"123\\"})
     with a.location as a_location, apoc.convert.fromJsonMap(a.address) as address
     match (node:Tripler) where node.zip starts with left(\\"12345\\", 3)
-      where
-        not ()-[:CLAIMS]->(node)
-        and not ()-[:WAS_ONCE]->(node)
-        
-        
-        
-        and node.age_decade in [\\"20-29\\"]
-        
-        
-      with a_location, node, null as first_n_q, null as last_n_q
-      with a_location, node, first_n_q, last_n_q,
-        
+    with a_location, address, node
+    where
+      not ()-[:CLAIMS]->(node)
+      and not ()-[:WAS_ONCE]->(node)
+      
+      
+      
+      and node.age_decade in [\\"20-29\\"]
+      
+      
+    with a_location, node, null as first_n_q, null as last_n_q
+    with a_location, node, first_n_q, last_n_q,
+      
     0 as score1, 0 as score2, 0 as score3
   
-      with
-        node, (score1 + score2 + score3) / 3 as avg_score,
-        distance(a_location, node.location) / 10000 as distance
-      with
-        node, avg_score + (1 / distance) * 0 as final_score
-      return node, final_score
-      order by final_score desc, node.last_name asc, node.first_name asc
-      limit 100
+    with
+      node, (score1 + score2 + score3) / 3 as avg_score,
+      distance(a_location, node.location) / 10000 as distance
+    with
+      node, avg_score + (1 / distance) * 0 as final_score
+    return node, final_score
+    order by final_score desc, node.last_name asc, node.first_name asc
+    limit 100
   "
 `;
 
@@ -35,30 +36,31 @@ exports[`triplers search query with everything 1`] = `
     match (a:Ambassador {id: \\"123\\"})
     with a.location as a_location, apoc.convert.fromJsonMap(a.address) as address
     CALL db.index.fulltext.queryNodes(\\"triplerFullNameIndex\\", \\"*foo* *bar*\\") YIELD node
-      where
-        not ()-[:CLAIMS]->(node)
-        and not ()-[:WAS_ONCE]->(node)
-        
-        and node.phone in [\\"15551212\\"]
-        and node.gender in [\\"F\\", \\"U\\"]
-        and node.age_decade in [\\"20-29\\"]
-        and node.msa in [\\"Jacksonville, FL area\\"]
-        and node.zip starts with left(\\"12345\\", 3)
-      with a_location, node, \\"foo\\" as first_n_q, \\"bar\\" as last_n_q
-      with a_location, node, first_n_q, last_n_q,
-        
+    with a_location, address, node
+    where
+      not ()-[:CLAIMS]->(node)
+      and not ()-[:WAS_ONCE]->(node)
+      
+      and node.phone in [\\"15551212\\"]
+      and node.gender in [\\"F\\", \\"U\\"]
+      and node.age_decade in [\\"20-29\\"]
+      and node.msa in [\\"Jacksonville, FL area\\"]
+      and node.zip starts with left(\\"12345\\", 3)
+    with a_location, node, \\"foo\\" as first_n_q, \\"bar\\" as last_n_q
+    with a_location, node, first_n_q, last_n_q,
+      
     apoc.text.levenshteinSimilarity(replace(replace(toLower(node.full_name), '-', ''), \\"'\\", ''), first_n_q + ' ' + last_n_q) as score1,
     apoc.text.jaroWinklerDistance(replace(replace(toLower(node.full_name), '-', ''), \\"'\\", ''), first_n_q + ' ' + last_n_q) as score2,
     apoc.text.sorensenDiceSimilarity(replace(replace(toLower(node.full_name), '-', ''), \\"'\\", ''), first_n_q + ' ' + last_n_q) as score3
   
-      with
-        node, (score1 + score2 + score3) / 3 as avg_score,
-        distance(a_location, node.location) / 10000 as distance
-      with
-        node, avg_score + (1 / distance) * 0.5 as final_score
-      return node, final_score
-      order by final_score desc, node.last_name asc, node.first_name asc
-      limit 100
+    with
+      node, (score1 + score2 + score3) / 3 as avg_score,
+      distance(a_location, node.location) / 10000 as distance
+    with
+      node, avg_score + (1 / distance) * 0.5 as final_score
+    return node, final_score
+    order by final_score desc, node.last_name asc, node.first_name asc
+    limit 100
   "
 `;
 
@@ -67,30 +69,31 @@ exports[`triplers search query with firstName only 1`] = `
     match (a:Ambassador {id: \\"123\\"})
     with a.location as a_location, apoc.convert.fromJsonMap(a.address) as address
     CALL db.index.fulltext.queryNodes(\\"triplerFirstNameIndex\\", \\"*foo*\\") YIELD node
-      where
-        not ()-[:CLAIMS]->(node)
-        and not ()-[:WAS_ONCE]->(node)
-        
-        
-        
-        
-        
-        and node.zip starts with left(\\"12345\\", 3)
-      with a_location, node, \\"foo\\" as first_n_q, null as last_n_q
-      with a_location, node, first_n_q, last_n_q,
-        
+    with a_location, address, node
+    where
+      not ()-[:CLAIMS]->(node)
+      and not ()-[:WAS_ONCE]->(node)
+      
+      
+      
+      
+      
+      and node.zip starts with left(\\"12345\\", 3)
+    with a_location, node, \\"foo\\" as first_n_q, null as last_n_q
+    with a_location, node, first_n_q, last_n_q,
+      
     apoc.text.levenshteinSimilarity(replace(replace(toLower(node.first_name), '-', ''), \\"'\\", ''), first_n_q) as score1,
     apoc.text.jaroWinklerDistance(replace(replace(toLower(node.first_name), '-', ''), \\"'\\", ''), first_n_q) as score2,
     apoc.text.sorensenDiceSimilarity(replace(replace(toLower(node.first_name), '-', ''), \\"'\\", ''), first_n_q) as score3
   
-      with
-        node, (score1 + score2 + score3) / 3 as avg_score,
-        distance(a_location, node.location) / 10000 as distance
-      with
-        node, avg_score + (1 / distance) * 0 as final_score
-      return node, final_score
-      order by final_score desc, node.last_name asc, node.first_name asc
-      limit 100
+    with
+      node, (score1 + score2 + score3) / 3 as avg_score,
+      distance(a_location, node.location) / 10000 as distance
+    with
+      node, avg_score + (1 / distance) * 0 as final_score
+    return node, final_score
+    order by final_score desc, node.last_name asc, node.first_name asc
+    limit 100
   "
 `;
 
@@ -99,30 +102,31 @@ exports[`triplers search query with fullName only 1`] = `
     match (a:Ambassador {id: \\"123\\"})
     with a.location as a_location, apoc.convert.fromJsonMap(a.address) as address
     CALL db.index.fulltext.queryNodes(\\"triplerFullNameIndex\\", \\"*foo* *bar*\\") YIELD node
-      where
-        not ()-[:CLAIMS]->(node)
-        and not ()-[:WAS_ONCE]->(node)
-        
-        
-        
-        
-        
-        and node.zip starts with left(\\"12345\\", 3)
-      with a_location, node, \\"foo\\" as first_n_q, \\"bar\\" as last_n_q
-      with a_location, node, first_n_q, last_n_q,
-        
+    with a_location, address, node
+    where
+      not ()-[:CLAIMS]->(node)
+      and not ()-[:WAS_ONCE]->(node)
+      
+      
+      
+      
+      
+      and node.zip starts with left(\\"12345\\", 3)
+    with a_location, node, \\"foo\\" as first_n_q, \\"bar\\" as last_n_q
+    with a_location, node, first_n_q, last_n_q,
+      
     apoc.text.levenshteinSimilarity(replace(replace(toLower(node.full_name), '-', ''), \\"'\\", ''), first_n_q + ' ' + last_n_q) as score1,
     apoc.text.jaroWinklerDistance(replace(replace(toLower(node.full_name), '-', ''), \\"'\\", ''), first_n_q + ' ' + last_n_q) as score2,
     apoc.text.sorensenDiceSimilarity(replace(replace(toLower(node.full_name), '-', ''), \\"'\\", ''), first_n_q + ' ' + last_n_q) as score3
   
-      with
-        node, (score1 + score2 + score3) / 3 as avg_score,
-        distance(a_location, node.location) / 10000 as distance
-      with
-        node, avg_score + (1 / distance) * 0 as final_score
-      return node, final_score
-      order by final_score desc, node.last_name asc, node.first_name asc
-      limit 100
+    with
+      node, (score1 + score2 + score3) / 3 as avg_score,
+      distance(a_location, node.location) / 10000 as distance
+    with
+      node, avg_score + (1 / distance) * 0 as final_score
+    return node, final_score
+    order by final_score desc, node.last_name asc, node.first_name asc
+    limit 100
   "
 `;
 
@@ -131,30 +135,31 @@ exports[`triplers search query with lastName only 1`] = `
     match (a:Ambassador {id: \\"123\\"})
     with a.location as a_location, apoc.convert.fromJsonMap(a.address) as address
     CALL db.index.fulltext.queryNodes(\\"triplerLastNameIndex\\", \\"*bar*\\") YIELD node
-      where
-        not ()-[:CLAIMS]->(node)
-        and not ()-[:WAS_ONCE]->(node)
-        
-        
-        
-        
-        
-        and node.zip starts with left(\\"12345\\", 3)
-      with a_location, node, null as first_n_q, \\"bar\\" as last_n_q
-      with a_location, node, first_n_q, last_n_q,
-        
+    with a_location, address, node
+    where
+      not ()-[:CLAIMS]->(node)
+      and not ()-[:WAS_ONCE]->(node)
+      
+      
+      
+      
+      
+      and node.zip starts with left(\\"12345\\", 3)
+    with a_location, node, null as first_n_q, \\"bar\\" as last_n_q
+    with a_location, node, first_n_q, last_n_q,
+      
     apoc.text.levenshteinSimilarity(replace(replace(toLower(node.last_name), '-', ''), \\"'\\", ''), last_n_q) as score1,
     apoc.text.jaroWinklerDistance(replace(replace(toLower(node.last_name), '-', ''), \\"'\\", ''), last_n_q) as score2,
     apoc.text.sorensenDiceSimilarity(replace(replace(toLower(node.last_name), '-', ''), \\"'\\", ''), last_n_q) as score3
   
-      with
-        node, (score1 + score2 + score3) / 3 as avg_score,
-        distance(a_location, node.location) / 10000 as distance
-      with
-        node, avg_score + (1 / distance) * 0 as final_score
-      return node, final_score
-      order by final_score desc, node.last_name asc, node.first_name asc
-      limit 100
+    with
+      node, (score1 + score2 + score3) / 3 as avg_score,
+      distance(a_location, node.location) / 10000 as distance
+    with
+      node, avg_score + (1 / distance) * 0 as final_score
+    return node, final_score
+    order by final_score desc, node.last_name asc, node.first_name asc
+    limit 100
   "
 `;
 
@@ -163,27 +168,28 @@ exports[`triplers search query without any parameters 1`] = `
     match (a:Ambassador {id: \\"123\\"})
     with a.location as a_location, apoc.convert.fromJsonMap(a.address) as address
     match (node:Tripler) where node.zip starts with left(\\"12345\\", 3)
-      where
-        not ()-[:CLAIMS]->(node)
-        and not ()-[:WAS_ONCE]->(node)
-         and node.zip starts with left(toString(address.zip), 3)
-        
-        
-        
-        
-        
-      with a_location, node, null as first_n_q, null as last_n_q
-      with a_location, node, first_n_q, last_n_q,
-        
+    with a_location, address, node
+    where
+      not ()-[:CLAIMS]->(node)
+      and not ()-[:WAS_ONCE]->(node)
+       and node.zip starts with left(toString(address.zip), 3)
+      
+      
+      
+      
+      
+    with a_location, node, null as first_n_q, null as last_n_q
+    with a_location, node, first_n_q, last_n_q,
+      
     0 as score1, 0 as score2, 0 as score3
   
-      with
-        node, (score1 + score2 + score3) / 3 as avg_score,
-        distance(a_location, node.location) / 10000 as distance
-      with
-        node, avg_score + (1 / distance) * 0 as final_score
-      return node, final_score
-      order by final_score desc, node.last_name asc, node.first_name asc
-      limit 100
+    with
+      node, (score1 + score2 + score3) / 3 as avg_score,
+      distance(a_location, node.location) / 10000 as distance
+    with
+      node, avg_score + (1 / distance) * 0 as final_score
+    return node, final_score
+    order by final_score desc, node.last_name asc, node.first_name asc
+    limit 100
   "
 `;

--- a/server/app/services/__snapshots__/triplers.jest.js.snap
+++ b/server/app/services/__snapshots__/triplers.jest.js.snap
@@ -13,7 +13,7 @@ exports[`triplers search query with age only 1`] = `
       
       and node.age_decade in [\\"20-29\\"]
       
-      
+      and node.zip starts with left(\\"12345\\", 3)
     with a_location, node, null as first_n_q, null as last_n_q
     with a_location, node, first_n_q, last_n_q,
       

--- a/server/app/services/__snapshots__/triplers.jest.js.snap
+++ b/server/app/services/__snapshots__/triplers.jest.js.snap
@@ -3,13 +3,12 @@
 exports[`triplers search query with age only 1`] = `
 "
     match (a:Ambassador {id: \\"123\\"})
-    with a.location as a_location, apoc.convert.fromJsonMap(a.address) as address
-    match (node:Tripler) where node.zip starts with left(\\"12345\\", 3)
-    with a_location, address, node
+    with a.location as a_location
+    match (node:Tripler)
+    with a_location, node
     where
       not ()-[:CLAIMS]->(node)
       and not ()-[:WAS_ONCE]->(node)
-      
       
       
       and node.age_decade in [\\"20-29\\"]
@@ -34,18 +33,17 @@ exports[`triplers search query with age only 1`] = `
 exports[`triplers search query with everything 1`] = `
 "
     match (a:Ambassador {id: \\"123\\"})
-    with a.location as a_location, apoc.convert.fromJsonMap(a.address) as address
+    with a.location as a_location
     CALL db.index.fulltext.queryNodes(\\"triplerFullNameIndex\\", \\"*foo* *bar*\\") YIELD node
-    with a_location, address, node
+    with a_location, node
     where
       not ()-[:CLAIMS]->(node)
       and not ()-[:WAS_ONCE]->(node)
-      
       and node.phone in [\\"15551212\\"]
       and node.gender in [\\"F\\", \\"U\\"]
       and node.age_decade in [\\"20-29\\"]
       and node.msa in [\\"Jacksonville, FL area\\"]
-      and node.zip starts with left(\\"12345\\", 3)
+      
     with a_location, node, \\"foo\\" as first_n_q, \\"bar\\" as last_n_q
     with a_location, node, first_n_q, last_n_q,
       
@@ -67,13 +65,12 @@ exports[`triplers search query with everything 1`] = `
 exports[`triplers search query with firstName only 1`] = `
 "
     match (a:Ambassador {id: \\"123\\"})
-    with a.location as a_location, apoc.convert.fromJsonMap(a.address) as address
+    with a.location as a_location
     CALL db.index.fulltext.queryNodes(\\"triplerFirstNameIndex\\", \\"*foo*\\") YIELD node
-    with a_location, address, node
+    with a_location, node
     where
       not ()-[:CLAIMS]->(node)
       and not ()-[:WAS_ONCE]->(node)
-      
       
       
       
@@ -100,9 +97,9 @@ exports[`triplers search query with firstName only 1`] = `
 exports[`triplers search query with fullName only 1`] = `
 "
     match (a:Ambassador {id: \\"123\\"})
-    with a.location as a_location, apoc.convert.fromJsonMap(a.address) as address
+    with a.location as a_location
     CALL db.index.fulltext.queryNodes(\\"triplerFullNameIndex\\", \\"*foo* *bar*\\") YIELD node
-    with a_location, address, node
+    with a_location, node
     where
       not ()-[:CLAIMS]->(node)
       and not ()-[:WAS_ONCE]->(node)
@@ -111,7 +108,6 @@ exports[`triplers search query with fullName only 1`] = `
       
       
       
-      and node.zip starts with left(\\"12345\\", 3)
     with a_location, node, \\"foo\\" as first_n_q, \\"bar\\" as last_n_q
     with a_location, node, first_n_q, last_n_q,
       
@@ -133,13 +129,12 @@ exports[`triplers search query with fullName only 1`] = `
 exports[`triplers search query with lastName only 1`] = `
 "
     match (a:Ambassador {id: \\"123\\"})
-    with a.location as a_location, apoc.convert.fromJsonMap(a.address) as address
+    with a.location as a_location
     CALL db.index.fulltext.queryNodes(\\"triplerLastNameIndex\\", \\"*bar*\\") YIELD node
-    with a_location, address, node
+    with a_location, node
     where
       not ()-[:CLAIMS]->(node)
       and not ()-[:WAS_ONCE]->(node)
-      
       
       
       
@@ -166,18 +161,17 @@ exports[`triplers search query with lastName only 1`] = `
 exports[`triplers search query without any parameters 1`] = `
 "
     match (a:Ambassador {id: \\"123\\"})
-    with a.location as a_location, apoc.convert.fromJsonMap(a.address) as address
-    match (node:Tripler) where node.zip starts with left(\\"12345\\", 3)
-    with a_location, address, node
+    with a.location as a_location
+    match (node:Tripler)
+    with a_location, node
     where
       not ()-[:CLAIMS]->(node)
       and not ()-[:WAS_ONCE]->(node)
-       and node.zip starts with left(toString(address.zip), 3)
       
       
       
       
-      
+      and node.zip starts with left(\\"12345\\", 3)
     with a_location, node, null as first_n_q, null as last_n_q
     with a_location, node, first_n_q, last_n_q,
       

--- a/server/app/services/triplers.js
+++ b/server/app/services/triplers.js
@@ -3,7 +3,7 @@ import stringFormat from "string-format";
 import neo4j from "neo4j-driver";
 import neode from "../lib/neode";
 import { serializeName } from "../lib/utils";
-import { normalizePhone } from "../lib/normalizers";
+import { normalizeGender, normalizePhone } from "../lib/normalizers";
 import mail from "../lib/mail";
 import { ov_config } from "../lib/ov_config";
 import sms from "../lib/sms";
@@ -272,7 +272,7 @@ function buildTriplerSearchQuery(req) {
   `;
 
   const phoneFilter = phone ? `and node.phone in ["${normalizePhone(phone)}"]` : '';
-  const genderFilter = gender ? `and node.gender in ["${gender}", "U"]` : '';
+  const genderFilter = gender ? `and node.gender in ["${normalizeGender(gender)}", "U"]` : '';
   const ageFilter = age ? `and node.age_decade in ["${age}"]` : '';
   const msaFilter = msa ? `and node.msa in ["${msa}"]` : '';
   // This will have already been included above if there's no name specified.

--- a/server/app/services/triplers.js
+++ b/server/app/services/triplers.js
@@ -233,6 +233,7 @@ function buildSearchTriplerQuery(query) {
   return neo4jquery
 }
 
+/** Specifically for cypher matching. */
 function normalizeName(name) {
   return (name || "").replace(/-'/g, "").toLowerCase();
 }
@@ -256,12 +257,10 @@ function calculateQueryPoints(query) {
 function buildTriplerSearchQuery(req) {
   const { firstName, lastName, phone, distance, age, gender, msa } = req.query;
 
-  const queryPoints = calculateQueryPoints(req.query);
-  // Guess whether this query will probably return too many results.
-  const isBroadQuery = queryPoints < 2;
-
   // Add an optional constraint for performance.
   const { zip } = JSON.parse(req.user.get('address'));
+  // Guess whether this query will probably return too many results.
+  const isBroadQuery = calculateQueryPoints(req.query) < 2;
   const zipFilter = isBroadQuery ? `and node.zip starts with left("${zip}", 3)` : '';
 
   const firstNameNorm = normalizeName(firstName);

--- a/server/app/services/triplers.js
+++ b/server/app/services/triplers.js
@@ -290,27 +290,27 @@ function buildTriplerSearchQuery(req) {
     match (a:Ambassador {id: "${req.user.get('id')}"})
     with a.location as a_location, apoc.convert.fromJsonMap(a.address) as address
     ${triplerQuery}
-      with a_location, address, node
-      where
-        not ()-[:CLAIMS]->(node)
-        and not ()-[:WAS_ONCE]->(node)
-        ${optionalZip}
-        ${phoneFilter}
-        ${genderFilter}
-        ${ageFilter}
-        ${msaFilter}
-        ${secondZipFilter}
-      with a_location, node, ${firstNameNorm ? `"${firstNameNorm}"` : null} as first_n_q, ${lastNameNorm ? `"${lastNameNorm}"` : null} as last_n_q
-      with a_location, node, first_n_q, last_n_q,
-        ${stringDistScores}
-      with
-        node, (score1 + score2 + score3) / 3 as avg_score,
-        distance(a_location, node.location) / 10000 as distance
-      with
-        node, avg_score + (1 / distance) * ${distanceValue} as final_score
-      return node, final_score
-      order by final_score desc, node.last_name asc, node.first_name asc
-      limit 100
+    with a_location, address, node
+    where
+      not ()-[:CLAIMS]->(node)
+      and not ()-[:WAS_ONCE]->(node)
+      ${optionalZip}
+      ${phoneFilter}
+      ${genderFilter}
+      ${ageFilter}
+      ${msaFilter}
+      ${secondZipFilter}
+    with a_location, node, ${firstNameNorm ? `"${firstNameNorm}"` : null} as first_n_q, ${lastNameNorm ? `"${lastNameNorm}"` : null} as last_n_q
+    with a_location, node, first_n_q, last_n_q,
+      ${stringDistScores}
+    with
+      node, (score1 + score2 + score3) / 3 as avg_score,
+      distance(a_location, node.location) / 10000 as distance
+    with
+      node, avg_score + (1 / distance) * ${distanceValue} as final_score
+    return node, final_score
+    order by final_score desc, node.last_name asc, node.first_name asc
+    limit 100
   `;
 }
 


### PR DESCRIPTION
Fixes https://github.com/colab-coop/HelloVoter/issues/102 and https://github.com/colab-coop/hello-voter/issues/180.

⚠️ I recommend viewing the single commit 0c26335 if you want to see the actual change to the search query without whitespace changes.

Context:
- Limiting by zip is merely for performance
- Results are always sorted by distance multiplied by the distance factor ("near me" to "doesn't matter") which defaults to "near me" on the frontend. This sorting will have no effect if set to "doesn't matter"; results are secondarily sorted by name

Change implemented here:
- If empty search OR if ONLY one name (first or last) is specified, limit by zip and sort by distance
- If any other search params beyond just one name are specified, don't limit by zip, just sort by distance (as always, modified by the distance factor as described above)

TODO/Open questions from me:
- [x] If you ONLY search for age or gender, should those both be considered "broad" and thus use the zip limitation too?
- [x] Test on staging data to make sure this is what you want
