### PR TITLE
refactoring buildTriplerSearchQuery

### DIFF
--- a/server/app/createExpressApp.js
+++ b/server/app/createExpressApp.js
@@ -143,8 +143,15 @@ export function doExpressInit(log, db, qq, neode) {
       */
 
       req.externalId = u.id;
-
+      
       let user = await ambassadorSvc.findByExternalId(u.id);
+
+      /*
+        Are you developing locally and having trouble linking your account to your test database?
+        Find a Ambassador you'd like to authenticate as and set the node's externalID parameter to 
+        the req.externalId produced here.
+      */
+
       if (user && user.get('locked')) {
         return _403(res, "Your account is locked.");
       }

--- a/server/scripts/seed_db.js
+++ b/server/scripts/seed_db.js
@@ -170,6 +170,20 @@ async function createAmbassador(opts) {
   return new_ambassador;
 }
 
+async function createSocialMatchNodes() {
+  let query =   ["MATCH (a:Tripler)",
+            "MATCH (b:Tripler)",
+            "WHERE a <> b",
+            "WITH  a, b, rand() as r",
+            "ORDER BY r",
+            "LIMIT 100",
+            "WITH  a, b",
+            "WHERE a <> b",
+            "MERGE (a)-[:HAS_SOCIAL_MATCH]->(s:SocialMatch)-[:HAS_SOCIAL_MATCH]->(b)",
+            "SET s.similarity_metric=rand()"].join("\n")
+  return neode.cypher(query,{})
+}
+
 async function createAdmin() {
   return createAmbassador({ admin: true });
 }
@@ -222,6 +236,9 @@ async function seed(args) {
     console.log(`Creating ${status} tripler ${index + 1} of ${max} ...`);
     await createTripler({ status });
   }
+
+  console.log("Creating sparse SocialMatch nodes...");
+  let socialMatchNodes = await createSocialMatchNodes();
 
   await addIndexes();
 }


### PR DESCRIPTION
refactored so to:

relates to https://www.pivotaltracker.com/story/show/175833600

* left note (bad) for workaround since I can't authenticate
* removed zip code filter and instead sorted by distance so I can see potential Triplers even if I'm in a different zip. This is part of the larger goal of presenting more search results
* added minimal SocialNode data to the initial dataset
* added the SocialNode similarity_ metric to the score that calculates what Triplers to show Ambassadors

Filters work and I'm presented w. location-relevant Triplers even when I'm not particularly looking for them

<img width="1079" alt="Screen Shot 2020-11-21 at 11 04 00 PM" src="https://user-images.githubusercontent.com/2731744/99893405-e5890c00-2c4d-11eb-9b8b-440262d08843.png">

 