### PR TITLE
if ambassador has no address, show empty string instead of null

### DIFF
--- a/server/app/routes/api/v1/va/serializers.js
+++ b/server/app/routes/api/v1/va/serializers.js
@@ -54,8 +54,8 @@ function serializeAmbassador(ambassador) {
   ].forEach((x) => (obj[x] = ambassador.get(x)))
   obj['address'] = !!ambassador.get('address')
     ? JSON.parse(ambassador.get('address').replace('#', 'no.'))
-    : null
-  obj['display_address'] = !!obj['address'] ? serializeAddress(obj['address']) : null
+    : ""
+  obj['display_address'] = !!obj['address'] ? serializeAddress(obj['address']) : ""
   obj['display_name'] = serializeName(ambassador.get('first_name'), ambassador.get('last_name'))
   obj['quiz_results'] = !!ambassador.get('quiz_results')
     ? JSON.parse(ambassador.get('quiz_results'))


### PR DESCRIPTION
This is to prevent the admin UI from breaking on a null address. 
Maybe it should be handled on the frontend? 

<img width="392" alt="Screen Shot 2020-11-30 at 11 14 42 PM" src="https://user-images.githubusercontent.com/2731744/100696575-d7c83a80-3361-11eb-83b1-3ff4b4811118.png">
