### PR TITLE
[dont merge, rate limit] make sure account-related ambassador fields are updated in hs

### DIFF
--- a/server/app/services/ambassadors.js
+++ b/server/app/services/ambassadors.js
@@ -321,6 +321,9 @@ async function getPrimaryAccount(ambassador) {
     }
   }
 
+  //make sure account-related ambassador fields are updated in hs
+  syncAmbassadorToHubSpot(ambassador)
+
   return primaryAccount
 }
 

--- a/server/app/services/ambassadors.js
+++ b/server/app/services/ambassadors.js
@@ -23,7 +23,12 @@ import {serializeAmbassadorForAdmin} from "../routes/api/v1/va/serializers"
  *
  */
 async function findByExternalId(externalId) {
-  return await neode.first("Ambassador", "external_id", externalId)
+
+  const ambassador = await neode.first("Ambassador", "external_id", externalId)
+  if(ambassador) {
+    syncAmbassadorToHubSpot(ambassador)
+  }
+  return ambassador
 }
 
 /*
@@ -322,7 +327,7 @@ async function getPrimaryAccount(ambassador) {
   }
 
   //make sure account-related ambassador fields are updated in hs
-  syncAmbassadorToHubSpot(ambassador)
+  // syncAmbassadorToHubSpot(ambassador)
 
   return primaryAccount
 }


### PR DESCRIPTION
this adds the "  syncAmbassadorToHubSpot(ambassador)" to when an ambassador goes to check in on their payment info. I'm having a little trouble testing this locally because of some missing env variables. 

These might be too many calls to hs 