### PR TITLE
In development mode, generate fake HubSpot IDs for Ambassadors.

### DIFF
--- a/server/app/lib/crm.js
+++ b/server/app/lib/crm.js
@@ -29,6 +29,11 @@ async function getAmbassadorHSID(email) {
       console.log(`[HS] Lookup failed with error ${err}`)
       return null
     }
+  } else {
+    if (process.env.NODE_ENV === 'development') {
+      // Return a fake key in development
+      return 'hubspot_id_' + email;
+    }
   }
 }
 
@@ -113,6 +118,8 @@ async function createHubspotContact(req) {
           },
         },
       )
+    } else {
+      console.log('[HS] HUBSPOT_API_KEY is not configured, skipping');
     }
     return response
   } catch (err) {

--- a/server/app/services/ambassadors.js
+++ b/server/app/services/ambassadors.js
@@ -191,14 +191,18 @@ async function initialSyncAmbassadorToHubSpot(ambassador) {
     "https://app.blockpower.vote/ambassadors/admin/#/volunteers/view/" + ambassador.get("id")
   if (!ambassador.get("hs_id")) {
     console.log("no hs id, gettig it from hs")
-    const hs_response = await getAmbassadorHSID(ambassador.get("email"))
+    let hs_response = await getAmbassadorHSID(ambassador.get("email"))
     if (!hs_response) {
       createHubspotContact(obj)
-      const hs_response = await getAmbassadorHSID(ambassador.get("email"))
+      hs_response = await getAmbassadorHSID(ambassador.get("email"))
+    }
+
+    if (!hs_response) {
+      return null;
     }
 
     let cypher_response = await neode.cypher(
-      "MATCH (a:Ambassador {id: $id}) SET a.hs_id=toInteger($hs_id) RETURN a.first_name, a.hs_id",
+      "MATCH (a:Ambassador {id: $id}) SET a.hs_id=$hs_id RETURN a.first_name, a.hs_id",
       {
         id: ambassador.get("id"),
         hs_id: hs_response,


### PR DESCRIPTION
The HubSpot API spec says that the "id" field is a string, so I think we should keep a string field in the database.  Do you anticipate any issues with this change?