### PR TITLE
Add the ALLOY_BYPASS_KEYWORD setting, which allows you to bypass Alloy checks.

### DIFF
--- a/server/app/lib/alloy.js
+++ b/server/app/lib/alloy.js
@@ -2,6 +2,12 @@ import {ov_config} from "./ov_config"
 import axios from "axios"
 import {internationalNumber} from "./normalizers"
 
+const isBypassEnabled = (first_name, last_name) => {
+  const keyword = (ov_config.alloy_bypass_keyword || '').trim().toLowerCase();
+  const fullName = (first_name + ' ' + last_name).toLowerCase();
+  return keyword && fullName.indexOf(keyword) >= 0;
+};
+
 /*
  *
  * verifyAlloy()
@@ -13,6 +19,18 @@ import {internationalNumber} from "./normalizers"
 export async function verifyAlloy(first_name, last_name, address, city, state, zip, birth_date) {
   let alloyKey = ov_config.alloy_key
   let alloySecret = ov_config.alloy_secret
+
+  if (isBypassEnabled(first_name, last_name)) {
+    const alloyId = Math.floor(Math.random()*100000000);
+    console.log(
+      `[ALLOY] Name "${first_name} ${last_name}" included bypass keyword; returning random Alloy ID ${alloyId}`
+    );
+    return {
+      data: {
+        alloy_person_id: alloyId
+      }
+    };
+  }
 
   console.log(
     `[ALLOY] Calling API with: ${first_name} ${last_name} ${address} ${city} ${state} ${zip} ${birth_date}`,
@@ -49,6 +67,13 @@ export async function fuzzyAlloy(first_name, last_name, state, zip) {
   let alloyKey = ov_config.alloy_key
   let alloySecret = ov_config.alloy_secret
 
+  if (isBypassEnabled(first_name, last_name)) {
+    const alloyId = Math.floor(Math.random()*100000000);
+    console.log(
+      `[ALLOY] Name "${first_name} ${last_name}" included bypass keyword; returning fuzzy match success`
+    );
+    return 1;
+  }
   console.log(`[ALLOY] Calling Fuzzy API with: ${first_name} ${last_name} ${state} ${zip}`)
 
   try {

--- a/server/app/lib/ov_config.js
+++ b/server/app/lib/ov_config.js
@@ -101,19 +101,19 @@ export const ov_config = {
   new_ambassador_signup_admin_email_subject: getConfig(
     "new_ambassador_signup_admin_email_subject",
     false,
-    null,
+    "Ambassador signed up",
   ),
   new_ambassador_signup_admin_email_body: getConfig(
     "new_ambassador_signup_admin_email_body",
     false,
-    null,
+    "",
   ),
   tripler_confirm_admin_email_subject: getConfig(
     "tripler_confirm_admin_email_subject",
     false,
-    null,
+    "Tripler confirmed",
   ),
-  tripler_confirm_admin_email_body: getConfig("tripler_confirm_admin_email_body", false, null),
+  tripler_confirm_admin_email_body: getConfig("tripler_confirm_admin_email_body", false, ""),
   disable_upgrade_sms: getConfig("disable_upgrade_sms", false, false),
   upgrade_sms_waiting_period: getConfig("upgrade_sms_waiting_period", true, null),
   upgrade_sms_schedule: getConfig("upgrade_sms_schedule", false, null),
@@ -148,6 +148,7 @@ export const ov_config = {
   // Alloy
   alloy_key: getConfig("alloy_key", true, ""),
   alloy_secret: getConfig("alloy_secret", true, ""),
+  alloy_bypass_keyword: getConfig("alloy_bypass_keyword", false, ""),
 
   // Voting plan links
   short_link_base_url: getConfig(

--- a/server/app/routes/api/v1/va/ambassadors.js
+++ b/server/app/routes/api/v1/va/ambassadors.js
@@ -357,7 +357,7 @@ async function signup(req, res) {
     }
   }
 
-  if (new_ambassador.approved) {
+  if (new_ambassador.get('approved')) {
     const plan = await createVotingPlan(new_ambassador);
     try {
       await sms(


### PR DESCRIPTION
This setting should never be set in production.

If ALLOY_BYPASS_KEYWORD is present and non-blank, then Alloy checks for a person with a first or last name containing the specified keyword will always pass and return a randomly generated Alloy person ID.  This feature is to enable testing of Alloy-approved user flows in staging.

This also fixes a bug that caused us to never send the welcome text to new ambassadors.