### PR TITLE
Only account for confirmed triplers in disbursement limit indication …

### DIFF
--- a/server/app/lib/ov_config.js
+++ b/server/app/lib/ov_config.js
@@ -91,7 +91,7 @@ export const ov_config = {
   ),
   suggest_tripler_limit: getConfig("suggest_tripler_limit", false, 1000),
   claim_tripler_limit: getConfig("claim_tripler_limit", false, 12),
-  needs_additional_1099_data_tripler_disbursement_limit: getConfig("needs_additional_1099_data_tripler_disbursement_limit", false, 50000), // in cents
+  needs_additional_1099_data_tripler_disbursement_limit: getConfig("needs_additional_1099_data_tripler_disbursement_limit", false, 45000), // in cents
   payout_schedule: getConfig("payout_schedule", false, 60),
   fifo_wakeup: getConfig("fifo_wakeup", false, 300),
   disable_auto_payouts: getConfig("disable_auto_payouts", true, false),

--- a/server/app/routes/api/v1/va/serializers.js
+++ b/server/app/routes/api/v1/va/serializers.js
@@ -102,7 +102,10 @@ function serializeAmbassador(ambassador) {
     const disbursementLimit = ov_config.needs_additional_1099_data_tripler_disbursement_limit;
     const perTriplerPaymentAmount = ov_config.payout_per_tripler;
 
-    const disbursedAmount = perTriplerPaymentAmount * claimees.length;
+    const claimeeStatuses = claimees.map(c => c.otherNode().get('status')); // get the confirmation status
+    const confirmedTriplerCount = claimeeStatuses.filter(s => s === 'confirmed').length; // count the matches
+
+    const disbursedAmount = perTriplerPaymentAmount * confirmedTriplerCount;
 
     if(disbursedAmount >= disbursementLimit){
       obj['needs_additional_1099_data'] = true;


### PR DESCRIPTION
…(i. e., the needs_additional_1099_data) flag, and ignore disbursement limit for the purpose of tripler claims entirely.