### PR TITLE
[2021] Switch to using an X-External-Id header for setting the external-id during testing

### DIFF
--- a/server/app/createExpressApp.js
+++ b/server/app/createExpressApp.js
@@ -197,10 +197,10 @@ function invite(req, res) {
 // Returns a promise for the Ambassador node for the authenticated user.
 function authenticateUser(req, res) {
   try {
-
-    if (ov_config.stress_testing && req.query.testingExternalId) {
+    if (ov_config.stress_testing && req.header('x-external-id')) {
       // In stress testing mode, allow the client to choose any external ID.
-      req.externalId = 'testing:' + req.query.testingExternalId;
+      req.externalId = 'testing:' + req.header('x-external-id');
+      console.log('Bypassing authentication with X-External-Id:', req.externalId);
     } else {
       if (!req.header('authorization')) {
         _400(res, "Missing required header.");


### PR DESCRIPTION
This should be merged only when @litenull is ready for them, because this would require a corresponding change to the stress-testing scripts that he's maintaining.