### PR TITLE
Fix storing of link click timestamp.

### DIFF
--- a/server/app/services/voting_plans.js
+++ b/server/app/services/voting_plans.js
@@ -46,10 +46,12 @@ const getVotingPlanUrl = (plan) =>
 
 const recordVotingPlanClick = async (plan) => {
   const clicks = plan.get('link_clicks');
+  const createTime = +plan.get('create_time');
   const timestamps = parseJson(clicks, []) || [];
   timestamps.push((new Date()).toISOString());
   await plan.update({
-    link_clicks: JSON.stringify(timestamps)
+    link_clicks: JSON.stringify(timestamps),
+    create_time: createTime
   });
 };
 


### PR DESCRIPTION
I don't know why I have to do this, but if I don't re-update `create_time`, I get a validation error complaining that `create_time` is not a number.  Even though it is already a number.  And all I am doing is storing the value of `create_time` back into `create_time`.  But somehow this fixes it.  Neo4j/Neode is confusing.